### PR TITLE
Add default for the finite field types which is all zeros.

### DIFF
--- a/src/digits/ff.rs
+++ b/src/digits/ff.rs
@@ -356,6 +356,13 @@ macro_rules! fp { ($modname: ident, $classname: ident, $bits: tt, $limbs: tt, $p
         }
     }
 
+    impl Default for $classname {
+        #[inline]
+        fn default() -> Self {
+            Zero::zero()
+        }
+    }
+
     impl $classname {
         ///Take the extra limb and incorporate that into the existing value by modding by the prime.
         #[inline]

--- a/src/digits/ff.rs
+++ b/src/digits/ff.rs
@@ -590,6 +590,11 @@ macro_rules! fp { ($modname: ident, $classname: ident, $bits: tt, $limbs: tt, $p
         use proptest::prelude::*;
         use rand::OsRng;
 
+        #[test]
+        fn default_is_zero() {
+            assert_eq!($classname::zero(), $classname::default())
+        }
+
         prop_compose! {
             fn arb_fp()(seed in any::<u64>()) -> $classname {
                 if seed == 0 {


### PR DESCRIPTION
Default allows downstream consumers to implement `Drop` using https://docs.rs/clear_on_drop/0.2.3/clear_on_drop/ on their types more easily. 