### PR TITLE
Rust 2018 Edition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 cache: cargo
 rust:
-  - 1.29.1
+  - 1.31.0
 branches:
   only:
     - master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "gridiron"
 version = "0.3.0"
+edition = "2018"
 authors = ["IronCore Labs <code at ironcorelabs.com>"]
 repository = "https://github.com/IronCoreLabs/gridiron"
 description = "Rust finite field library with fixed size multi-word values."

--- a/src/digits/constant_time_primitives.rs
+++ b/src/digits/constant_time_primitives.rs
@@ -3,7 +3,7 @@
  * https://www.bearssl.org/gitweb/?p=BearSSL;a=blob;f=src/inner.h
  */
 
-use digits::constant_bool::*;
+use crate::digits::constant_bool::*;
 use num_traits::{NumOps, One, Zero};
 use std::cmp::Ordering;
 use std::mem::size_of;

--- a/src/digits/ff31.rs
+++ b/src/digits/ff31.rs
@@ -544,9 +544,10 @@ macro_rules! fp31 {
                 }
                 #[inline]
                 pub fn to_monty(self) -> Monty {
-                    Monty { limbs: self.limbs } * Monty {
-                        limbs: MONTRSQUARED,
-                    }
+                    Monty { limbs: self.limbs }
+                        * Monty {
+                            limbs: MONTRSQUARED,
+                        }
                 }
 
                 ///See normalize_little_limbs.
@@ -768,7 +769,7 @@ macro_rules! fp31 {
                     ctl: ConstantBool<u32>,
                 ) -> ConstantBool<u32> {
                     let mut cc = 0u32;
-                    for (mut aa, bb) in a.iter_mut().zip(b.iter()) {
+                    for (aa, bb) in a.iter_mut().zip(b.iter()) {
                         let aw = *aa;
                         let bw = *bb;
                         let naw = aw.wrapping_add(bw).wrapping_add(cc);
@@ -786,7 +787,7 @@ macro_rules! fp31 {
                     ctl: ConstantBool<u32>,
                 ) -> ConstantBool<u32> {
                     let mut cc = 0u32;
-                    for (mut aa, bb) in a.iter_mut().zip(b.iter()) {
+                    for (aa, bb) in a.iter_mut().zip(b.iter()) {
                         let aw = *aa;
                         let bw = *bb;
                         let naw = aw.wrapping_sub(bw).wrapping_sub(cc);
@@ -800,7 +801,7 @@ macro_rules! fp31 {
                 fn sub_assign_limbs_slice(a: &mut [u32], b: &[u32]) -> ConstantBool<u32> {
                     debug_assert!(a.len() == b.len());
                     let mut cc = 0u32;
-                    for (mut aa, bb) in a.iter_mut().zip(b.iter()) {
+                    for (aa, bb) in a.iter_mut().zip(b.iter()) {
                         let aw = *aa;
                         let bw = *bb;
                         let naw = aw.wrapping_sub(bw).wrapping_sub(cc);
@@ -828,7 +829,7 @@ macro_rules! fp31 {
                 fn cond_negate(a: &mut [u32; NUMLIMBS], ctl: ConstantBool<u32>) {
                     let mut cc = ctl.0;
                     let xm = ctl.0.wrapping_neg() >> 1;
-                    for mut ai in a.iter_mut() {
+                    for ai in a.iter_mut() {
                         let mut aw = *ai;
                         aw = (aw ^ xm) + cc;
                         *ai = aw & 0x7FFFFFFF;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-use digits::util::unsafe_convert_bytes_to_limbs_mut;
+use crate::digits::util::unsafe_convert_bytes_to_limbs_mut;
 
 extern crate num_traits;
 #[cfg(test)]
@@ -366,7 +366,7 @@ mod lib {
 
     #[test]
     fn fp256_to_bytes_known_good_value() {
-        use fp_256::Fp256;
+        use crate::fp_256::Fp256;
         let fp = Fp256::from(255u32);
         let bytes = fp.to_bytes_array();
         let expected_result = {
@@ -379,7 +379,7 @@ mod lib {
 
     #[test]
     fn fp256_from_bytes_should_mod() {
-        use fp_256::Fp256;
+        use crate::fp_256::Fp256;
         let max_bytes = Fp256::from([255u8; 32]);
         let expected_result = Fp256::new([
             569862552, 1330030375, 2099849607, 220445046, 1739734497, 839018739, 1461584277,


### PR DESCRIPTION
This shouldn't have any external changes. I don't fully understand the removal of the `mut`. Does that affect the constant-time-ness of those functions?