### PR TITLE
Remove duplicate Mul and Pow implementations. Standardize on u32.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gridiron"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2018"
 authors = ["IronCore Labs <code at ironcorelabs.com>"]
 repository = "https://github.com/IronCoreLabs/gridiron"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gridiron"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2018"
 authors = ["IronCore Labs <code at ironcorelabs.com>"]
 repository = "https://github.com/IronCoreLabs/gridiron"

--- a/src/digits/ff31.rs
+++ b/src/digits/ff31.rs
@@ -214,15 +214,6 @@ macro_rules! fp31 {
                 type Output = $classname;
                 #[inline]
                 fn mul(self, rhs: u32) -> $classname {
-                    util::sum_n(self, rhs as u64)
-                }
-            }
-            ///Note that this reveals the u64, but nothing else. It's expected that the u32 is not secret.
-            ///If it is, you can use Mul<$classname>
-            impl Mul<u64> for $classname {
-                type Output = $classname;
-                #[inline]
-                fn mul(self, rhs: u64) -> $classname {
                     util::sum_n(self, rhs)
                 }
             }
@@ -245,10 +236,10 @@ macro_rules! fp31 {
             }
 
             ///Reveals the exponent. If you need constant time, use Pow<$classname>
-            impl Pow<u64> for $classname {
+            impl Pow<u32> for $classname {
                 type Output = $classname;
                 #[inline]
-                fn pow(self, rhs: u64) -> $classname {
+                fn pow(self, rhs: u32) -> $classname {
                     util::exp_by_squaring(self, rhs)
                 }
             }
@@ -421,22 +412,22 @@ macro_rules! fp31 {
                 }
             }
 
-            ///Note that this reveals the u64, but nothing else. It's expected that the u32 is not secret.
+            ///Note that this reveals the u32, but nothing else. It's expected that the u32 is not secret.
             ///If it is, you can use Mul<$classname>
-            impl Mul<u64> for Monty {
+            impl Mul<u32> for Monty {
                 type Output = Monty;
                 #[inline]
-                fn mul(self, rhs: u64) -> Monty {
+                fn mul(self, rhs: u32) -> Monty {
                     util::sum_n(self, rhs)
                 }
             }
 
             ///Note that this reveals the exponent, but nothing else. If you need constant time for the exponent, use
             ///Pow<$classname>.
-            impl Pow<u64> for Monty {
+            impl Pow<u32> for Monty {
                 type Output = Monty;
                 #[inline]
-                fn pow(self, rhs: u64) -> Monty {
+                fn pow(self, rhs: u32) -> Monty {
                     util::exp_by_squaring(self, rhs)
                 }
             }
@@ -1271,8 +1262,8 @@ macro_rules! fp31 {
 
                     #[test]
                     fn add_equals_mult(a in arb_fp()) {
-                        prop_assert_eq!(a + a, a * 2u64);
-                        prop_assert_eq!(a + a + a, a * 3u64);
+                        prop_assert_eq!(a + a, a * 2u32);
+                        prop_assert_eq!(a + a + a, a * 3u32);
                     }
 
                     #[test]

--- a/src/digits/util.rs
+++ b/src/digits/util.rs
@@ -44,7 +44,7 @@ pub fn u32_to_bytes_big_endian(x: u32, buf: &mut [u8]) {
 
 ///Sum t n times. Reveals the value of n.
 #[inline]
-pub fn sum_n<T: Zero + Copy>(mut t: T, n: u64) -> T {
+pub fn sum_n<T: Zero + Copy>(mut t: T, n: u32) -> T {
     if n == 0 {
         Zero::zero()
     } else if n == 1 {
@@ -64,13 +64,12 @@ pub fn sum_n<T: Zero + Copy>(mut t: T, n: u64) -> T {
 
 ///This reveals the exponent so it should not be called with secret values.
 #[inline]
-pub fn exp_by_squaring<T: One + Copy>(orig_x: T, nn: u64) -> T {
-    if nn == 0 {
+pub fn exp_by_squaring<T: One + Copy>(orig_x: T, mut n: u32) -> T {
+    if n == 0 {
         T::one()
     } else {
         let mut y = T::one();
         let mut x = orig_x;
-        let mut n = nn;
         while n > 1 {
             if (n & 1) == 0 {
                 x = x * x;


### PR DESCRIPTION
Our multiplication by u32 and u64 are not constant time and should only be called with known public values. In order to simplify and standardize on a single version we chose to just implement the u32 and call out that it's not CT.