### PR TITLE
Add inverse to Monty, fix definition of one.

### DIFF
--- a/src/digits/ff31.rs
+++ b/src/digits/ff31.rs
@@ -573,11 +573,7 @@ macro_rules! fp31 {
             impl One for Monty {
                 #[inline]
                 fn one() -> Self {
-                    let mut ret = $classname {
-                        limbs: [0u32; NUMLIMBS],
-                    };
-                    ret.limbs[0] = 1u32;
-                    ret.to_monty() //COLT: This is horribly inefficient
+                    $classname::one().to_monty() //this is horribly inefficient, but I don't know of a way to compute it without making the macro even uglier.
                 }
 
                 #[inline]
@@ -1438,7 +1434,7 @@ macro_rules! fp31 {
                         prop_assert_eq!(result.to_norm(), a + b)
                     }
 
-                                        #[test]
+                    #[test]
                     fn monty_one_is_mul_ident(a in arb_fp(), b in arb_fp()) {
                         let result = a.to_monty() * Monty::one() * b.to_monty();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,14 @@ impl From<[u8; 64]> for fp_256::Fp256 {
     }
 }
 
+impl From<[u8; 64]> for fp_256::Monty {
+    fn from(src: [u8; 64]) -> Self {
+        let mut limbs = [0u32; 18];
+        unsafe_convert_bytes_to_limbs_mut(&src, &mut limbs, 64);
+        fp_256::Fp256::new(fp_256::Fp256::reduce_barrett(&limbs)).to_monty()
+    }
+}
+
 impl From<[u8; 64]> for fp_480::Fp480 {
     fn from(src: [u8; 64]) -> Self {
         let mut limbs = [0u32; 32];


### PR DESCRIPTION
Make Monty be able to be used from recrypt all the time. It couldn't before because it lacked inverse. It turns out that even with a super inefficient inverse, it's still way faster than using non montgomery form.