### PR TITLE
Allowing users to receive PublicKey and PrivateKey as JSON String

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,14 +28,13 @@ jobs:
           command: check
 
   build_linux:
-    name: (Linux) Builds 
+    name: (Linux) Builds
     runs-on: ubuntu-18.04
     strategy:
       matrix:
         target:
-          - armv7-linux-androideabi     # Android ARM7
-          - aarch64-linux-android       # Android x64
-          - x86_64-unknown-linux-musl   # Alpine Linux x86_64
+          - aarch64-linux-android # Android x64
+          - x86_64-unknown-linux-musl # Alpine Linux x86_64
           - wasm32-unknown-unknown
     steps:
       - uses: actions/checkout@v2
@@ -51,12 +50,11 @@ jobs:
           args: --release --target=${{ matrix.target }}
 
   build_macos:
-    name: (OS X) Builds 
+    name: (OS X) Builds
     runs-on: macos-10.15
     strategy:
       matrix:
         target:
-          - armv7-apple-ios
           - aarch64-apple-ios
           - x86_64-apple-darwin # 64-bit OSX
     steps:
@@ -73,7 +71,7 @@ jobs:
           args: --release --target=${{ matrix.target }}
 
   build_win:
-    name: (Windows) Builds 
+    name: (Windows) Builds
     runs-on: windows-2019
     strategy:
       matrix:
@@ -110,7 +108,7 @@ jobs:
         with:
           command: test
 
-# commented out as the benches do not currently compile
+  # commented out as the benches do not currently compile
   # bench_build:
   #   name: Bench Compile
   #   runs-on: ubuntu-18.04

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,13 @@ keywords = ["finite", "field", "crypto", "math"]
 num-traits = "~0.2.11"
 arrayref = "0.3.6"
 
+[dependencies.serde_crate]
+package = "serde"
+optional = true
+version = "1.0.89"
+default-features = false
+features = ["std", "derive"]
+
 [profile.test]
 opt-level = 2
 debug = 2
@@ -29,6 +36,7 @@ criterion = "~0.3.0"
 
 [features]
 unstable = []
+serde = ["serde_crate"]
 
 [profile.bench]
 opt-level = 3

--- a/src/digits/ff31.rs
+++ b/src/digits/ff31.rs
@@ -61,7 +61,11 @@ macro_rules! fp31 {
             ///
             ///If you are doing more than 1 multiplication, it's clearly a win.
             #[derive(Debug, PartialEq, Eq, Ord, Clone, Copy)]
-            #[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(crate = "serde_crate"))]
+            #[cfg_attr(
+                feature = "serde",
+                derive(Serialize, Deserialize),
+                serde(crate = "serde_crate")
+            )]
             pub struct Monty {
                 pub(crate) limbs: [u32; NUMLIMBS],
             }

--- a/src/digits/ff31.rs
+++ b/src/digits/ff31.rs
@@ -35,6 +35,9 @@ macro_rules! fp31 {
             use $crate::digits::constant_bool::*;
             use $crate::digits::constant_time_primitives::*;
             use $crate::digits::util;
+            // Optional serde for PrivateKey and PublicKey structs
+            #[cfg(feature = "serde")]
+            use serde_crate::{Deserialize, Serialize};
 
             pub const LIMBSIZEBITS: usize = 31;
             pub const BITSPERBYTE: usize = 8;
@@ -58,6 +61,7 @@ macro_rules! fp31 {
             ///
             ///If you are doing more than 1 multiplication, it's clearly a win.
             #[derive(Debug, PartialEq, Eq, Ord, Clone, Copy)]
+            #[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(crate = "serde_crate"))]
             pub struct Monty {
                 pub(crate) limbs: [u32; NUMLIMBS],
             }


### PR DESCRIPTION
I noticed this request/issue < #89 > , by @drbh , which mentioned being able to serialize and deserialize recrypt data structures (to store on disk etc.)

I have updated both recrypt-rs and gridiron so that they both implement serde as an optional feature. Users/calling-code can choose to take advantage of the feature in the event that they want to be able to read and write the PrivateKey and PublicKey fields to disk (or return these values back to the calling code etc.)

Please see the other PR at https://github.com/IronCoreLabs/recrypt-rs/pull/109 which goes hand in hand with this PR