### PR TITLE
Add dependabot, update prop-test to ~0.10, bump MSRV

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.38.0 #MSRV
+          - 1.40.0 # MSRV
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -96,7 +96,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.38.0
+          - 1.40.0
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.8.0
+
+- [[#36]](https://github.com/IronCoreLabs/gridiron/pull/36)
+  - Update to proptest to 0.10 (Test only change)
+  - Change MSRV to Rust 1.40.0
+
 ## 0.7.0
 
 - [[#30]](https://github.com/IronCoreLabs/gridiron/pull/30) - Update to Rand 0.7 (Test only change)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ incremental = true
 overflow-checks = true
 
 [dev-dependencies]
-proptest = "0.9.4"
+proptest = "~0.10"
 rand = "~0.7.3"
 criterion = "~0.3.0"
 

--- a/src/digits/ff31.rs
+++ b/src/digits/ff31.rs
@@ -1229,7 +1229,7 @@ macro_rules! fp31 {
                     #[test]
                     #[should_panic]
                     fn div_by_zero_should_panic(a in arb_fp()) {
-                        a / $classname::zero()
+                        let _ = a / $classname::zero();
                     }
 
                     #[test]


### PR DESCRIPTION
This was causing issues with updating `prop-test` in `recrypt-rs`, so fixing that here.
Running `cargo update` shows that all other deps are up-to-date, so adding dependabot should be an easy win.
MSRV also had to be updated to 1.40.0 to fix an issue in a transitive dependency of `proptest` v0.9.6