### PR TITLE
unwind instead of should_panic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gridiron"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2018"
 authors = ["IronCore Labs <code at ironcorelabs.com>"]
 repository = "https://github.com/IronCoreLabs/gridiron"

--- a/src/digits/ff31.rs
+++ b/src/digits/ff31.rs
@@ -1227,9 +1227,8 @@ macro_rules! fp31 {
                     }
 
                     #[test]
-                    #[should_panic]
                     fn div_by_zero_should_panic(a in arb_fp()) {
-                        let _ = a / $classname::zero();
+                        assert!(std::panic::catch_unwind(|| a / $classname::zero()).is_err());
                     }
 
                     #[test]


### PR DESCRIPTION
In our test about div by 0, we used the should_panic annotation on the test. This causes the test to pass, but makes proptest write out a seed incorrectly. Instead of using `should_panic` we can use catch_unwind in the test and check for errors.